### PR TITLE
Fix header markup for sticky behavior

### DIFF
--- a/Header.liquid
+++ b/Header.liquid
@@ -168,8 +168,9 @@
   }
 </script>
 
-<header-component
-  id="header-component"
+<header class="header-section">
+  <header-component
+    id="header-component"
   class="{{ class }}"
   {% if transparent %}
     transparent="{{ transparent }}"
@@ -249,6 +250,7 @@
     </div>
   {% endif %}
 </header-component>
+</header>
 
 <script
   src="{{ 'header.js' | asset_url }}"


### PR DESCRIPTION
## Summary
- wrap `<header-component>` in `<header class="header-section">`
- close header before the script block

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686b4ff52b70832faceb118d7fafd11f